### PR TITLE
fix(workflow): add contents write permission to code-quality job

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -125,6 +125,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs['docs-only'] == 'false'
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

GitHub Actions の code-quality ジョブに `contents: write` パーミッションを追加し、github-actions[bot] が dist/ ディレクトリの変更を main/develop ブランチにプッシュできるようにしました。

## 変更内容

### 修正箇所

- `.github/workflows/quality.yml:128-129` に permissions セクションを追加
- `contents: write` 権限を付与

### 解決した問題

以下のエラーが解消されます:
```
remote: Permission to jey3dayo/pr-metrics-action.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/jey3dayo/pr-metrics-action/': The requested URL returned error: 403
```

## テスト計画

- [x] ワークフローが正常に実行されることを確認 (Run ID: 18598246414)
- [x] Code Quality ジョブが成功することを確認
- [x] 既存のテストがすべて成功することを確認

## 動作確認

feat/fix-workflow ブランチでの実行結果:
- ✅ Detect Changes: 成功
- ✅ Code Quality: 成功 (33秒)
  - ✅ Linting
  - ✅ Type checking
  - ✅ Tests
  - ✅ Build
  - ℹ️ Commit dist: スキップ (変更なし)
- ✅ Documentation Quality: 成功
- ✅ Quality Gate: 成功

## チェックリスト

- [x] ワークフロー設定の修正
- [x] 権限設定の追加
- [x] ローカルでの動作確認
- [x] CI/CDでの動作確認
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)