### PR TITLE
docs: add concrete examples and language setting to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,10 +13,15 @@
 インテリジェントな自動化でPRレビュープロセスを効率化:
 
 - **📏 スマートなサイズ検出**: PRサイズ（small → xxlarge）を自動ラベリングし、レビュー優先度の判断をサポート
+  - 例: `size/small`, `size/medium`, `size/large`, `size/xlarge`, `size/xxlarge`
 - **🏷️ 自動カテゴリ分類**: 変更タイプ（テスト、ドキュメント、CI/CD、依存関係）を自動判定し、素早いフィルタリングを実現
+  - 例: `category/tests`, `category/documentation`, `category/ci-cd`, `category/dependencies`
 - **⚠️ リスク評価**: テストなしのコア変更を事前に検出し、マージ前に警告
+  - 例: `risk/high`（テスト更新を伴わないコア変更）、`risk/medium`（設定・インフラ変更）
 - **📁 パスベースラベル**: 柔軟なGlobパターンでファイルパスに基づくカスタムラベルを適用
+  - 例: `frontend/**` → `team/frontend`, `backend/**` → `team/backend`
 - **🚦 品質ゲート**: 大きすぎるPRやポリシー違反時にワークフローを失敗させるオプション機能
+  - 例: `fail_on_pr_size: "xlarge"` で xlarge 以上のPRでワークフロー失敗
 - **🌐 多言語対応**: 英語・日本語の完全サポート
 
 ## 🚀 クイックスタート
@@ -48,6 +53,8 @@ jobs:
       - uses: jey3dayo/pr-labeler@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # 言語設定（デフォルトは英語）
+          # language: "ja"  # 日本語出力にする場合はコメントを外す
 ```
 
 ### 2. 自動適用されるラベル

--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@
 Streamline your PR review process with intelligent automation:
 
 - **📏 Smart Size Detection**: Automatically label PRs by size (small → xxlarge) to help reviewers prioritize
+  - Example: `size/small`, `size/medium`, `size/large`, `size/xlarge`, `size/xxlarge`
 - **🏷️ Auto-Categorization**: Classify changes by type (tests, docs, CI/CD, dependencies) for quick filtering
+  - Example: `category/tests`, `category/documentation`, `category/ci-cd`, `category/dependencies`
 - **⚠️ Risk Assessment**: Flag high-risk changes (core modifications without tests) before merge
+  - Example: `risk/high` (core changes without test updates), `risk/medium` (config/infrastructure changes)
 - **📁 Path-Based Labels**: Custom labels based on file paths using flexible glob patterns
+  - Example: `frontend/**` → `team/frontend`, `backend/**` → `team/backend`
 - **🚦 Quality Gates**: Optional workflow failures for oversized PRs or policy violations
+  - Example: `fail_on_pr_size: "xlarge"` fails workflow for xlarge or larger PRs
 - **🌐 Multi-language**: Full support for English and Japanese output
 
 ## 🚀 Quick Start
@@ -48,6 +53,8 @@ jobs:
       - uses: jey3dayo/pr-labeler@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Language setting (defaults to English)
+          # language: "ja"  # Uncomment for Japanese output
 ```
 
 ### 2. What You Get


### PR DESCRIPTION
## Summary

Add practical examples and language configuration guidance to improve user understanding of PR Labeler features.

### Changes

**✨ Feature Examples Added:**
- **Size labels**: `size/small`, `size/medium`, `size/large`, `size/xlarge`, `size/xxlarge`
- **Category labels**: `category/tests`, `category/documentation`, `category/ci-cd`, `category/dependencies`
- **Risk labels**: `risk/high` (core changes without tests), `risk/medium` (config/infra changes)
- **Path-based labels**: `frontend/**` → `team/frontend`, `backend/**` → `team/backend`
- **Quality gates**: `fail_on_pr_size: "xlarge"` behavior explanation

**🌐 Language Setting Enhancement:**
- Added commented-out `language` setting in Quick Start workflow example
- Clear guidance for Japanese output (uncomment `# language: "ja"` to enable)
- Maintains English as default while making i18n feature discoverable

### Benefits

- ✅ Users can visualize actual label names before deployment
- ✅ Language configuration is discoverable in first example
- ✅ Reduces configuration questions by showing concrete output
- ✅ Quick Start remains simple while exposing key options
- ✅ Both English (README.md) and Japanese (README.ja.md) updated consistently

### Test Plan

- [x] Verify markdown rendering on GitHub
- [x] Confirm examples align with actual label output
- [x] Check language setting comments are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example configurations for various label types (size, category, risk, path-based) to help users understand label usage.
  * Included commented language configuration examples in workflow documentation to demonstrate additional configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->